### PR TITLE
feat: rebrand site from Inkwell to JP

### DIFF
--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -61,7 +61,7 @@ export default function AdminLayout({
             href="/admin"
             className="text-lg font-bold text-accent-600 dark:text-accent-400"
           >
-            Inkwell Admin
+            JP Admin
           </Link>
           <button
             onClick={() => setSidebarOpen(false)}

--- a/app/api/site-config/route.ts
+++ b/app/api/site-config/route.ts
@@ -55,7 +55,7 @@ export async function PUT(request: NextRequest) {
   } else {
     config = await prisma.siteConfig.create({
       data: {
-        siteName: siteName ?? "Inkwell",
+        siteName: siteName ?? "JP",
         siteDescription: siteDescription ?? "",
         ownerName: ownerName ?? "",
         ownerTitle: ownerTitle ?? "",

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -25,7 +25,7 @@ export async function GET() {
     },
   });
 
-  const siteName = config?.siteName ?? "Inkwell";
+  const siteName = config?.siteName ?? "JP";
   const siteDesc = config?.siteDescription ?? "Developer Portfolio";
 
   const items = posts

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,8 +17,8 @@ const jetbrainsMono = JetBrains_Mono({
 
 export const metadata: Metadata = {
   title: {
-    default: "Inkwell | Developer Portfolio",
-    template: "%s | Inkwell",
+    default: "JP | Developer Portfolio",
+    template: "%s | JP",
   },
   description:
     "A developer portfolio showcasing projects, blog posts, and professional experience.",
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "en_US",
-    siteName: "Inkwell",
+    siteName: "JP",
   },
   twitter: {
     card: "summary_large_image",

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -17,7 +17,7 @@ export function Footer() {
       <Container className="py-8">
         <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
           <p className="text-sm text-neutral-500 dark:text-neutral-400">
-            &copy; {currentYear} Inkwell. All rights reserved.
+            &copy; {currentYear} JP. All rights reserved.
           </p>
           <div className="flex items-center gap-4">
             {socialLinks.map((link) => (

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -33,7 +33,7 @@ export function Header() {
             href="/"
             className="text-xl font-bold tracking-tight text-neutral-900 dark:text-white"
           >
-            Inkwell
+            JP
           </Link>
 
           <nav className="hidden items-center gap-1 md:flex">

--- a/prisma/seed-admin.ts
+++ b/prisma/seed-admin.ts
@@ -31,7 +31,7 @@ async function main() {
   if (!existingConfig) {
     await prisma.siteConfig.create({
       data: {
-        siteName: "Inkwell",
+        siteName: "JP",
         siteDescription: "A developer portfolio and blog",
         ownerName: "Your Name",
         ownerTitle: "Full-Stack Developer",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -91,7 +91,7 @@ async function main() {
   // Create site config
   await prisma.siteConfig.create({
     data: {
-      siteName: "Inkwell",
+      siteName: "JP",
       siteDescription: "A developer portfolio showcasing projects, blog posts, and professional experience.",
       ownerName: "Alex Morgan",
       ownerTitle: "Senior Full-Stack Developer",


### PR DESCRIPTION
## Summary

- Page title: "Inkwell | Developer Portfolio" → "JP | Developer Portfolio"
- Header logo: "Inkwell" → "JP"
- Footer copyright: "Inkwell" → "JP"
- Admin sidebar: "Inkwell Admin" → "JP Admin"
- OpenGraph siteName: "JP"
- RSS feed fallback name: "JP"
- Site-config API default: "JP"
- Seed data defaults: "JP"

Documentation (README, CLAUDE.md) retains "Inkwell" as the project codename.

Closes #27

## Test plan

- [ ] Verify page title in browser tab shows "JP | Developer Portfolio"
- [ ] Check header shows "JP" logo text
- [ ] Check footer copyright says "JP"
- [ ] Verify admin sidebar says "JP Admin"
- [ ] View page source to confirm OpenGraph siteName is "JP"

🤖 Generated with [Claude Code](https://claude.com/claude-code)