### PR TITLE
feat: replace generic intro with specific developer value proposition

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -44,11 +44,11 @@ export default async function HomePage() {
     // Database may be waking up (cold start) — render with defaults
   }
 
-  const ownerName = config?.ownerName ?? "Developer";
+  const ownerName = config?.ownerName ?? "JP";
   const ownerTitle = config?.ownerTitle ?? "Full-Stack Developer";
   const ownerBio =
     config?.ownerBio ??
-    "I build things for the web. Welcome to my corner of the internet where I share my projects, thoughts on software engineering, and lessons learned along the way.";
+    "Full-Stack Developer specializing in serverless AWS architecture, React, and TypeScript. I build scalable web applications from cloud infrastructure to polished UI.";
 
   return (
     <>

--- a/prisma/seed-admin.ts
+++ b/prisma/seed-admin.ts
@@ -33,9 +33,9 @@ async function main() {
       data: {
         siteName: "JP",
         siteDescription: "A developer portfolio and blog",
-        ownerName: "Your Name",
+        ownerName: "JP",
         ownerTitle: "Full-Stack Developer",
-        ownerBio: "Welcome to my portfolio. Update this in the admin settings.",
+        ownerBio: "Full-Stack Developer specializing in serverless AWS architecture, React, and TypeScript. I build scalable web applications from cloud infrastructure to polished UI.",
       },
     });
     console.log("Created default site config");

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -93,13 +93,13 @@ async function main() {
     data: {
       siteName: "JP",
       siteDescription: "A developer portfolio showcasing projects, blog posts, and professional experience.",
-      ownerName: "Alex Morgan",
-      ownerTitle: "Senior Full-Stack Developer",
-      ownerBio: "I build scalable web applications and cloud infrastructure. With 8+ years of experience shipping products used by millions, I write about software engineering, architecture, and the tools that make developers more productive.",
-      githubUrl: "https://github.com/alexmorgan",
-      linkedinUrl: "https://linkedin.com/in/alexmorgan",
-      twitterUrl: "https://twitter.com/alexmorgan",
-      email: "alex@example.com",
+      ownerName: "JP",
+      ownerTitle: "Full-Stack Developer",
+      ownerBio: "Full-Stack Developer specializing in serverless AWS architecture, React, and TypeScript. I build scalable web applications from cloud infrastructure to polished UI.",
+      githubUrl: "https://github.com/jpDxsolo",
+      linkedinUrl: "https://linkedin.com/in/jp",
+      twitterUrl: null,
+      email: null,
     },
   });
   console.log("Created site config");


### PR DESCRIPTION
## Summary

- Homepage fallback bio updated from generic "I build things for the web..." to specific "Full-Stack Developer specializing in serverless AWS architecture, React, and TypeScript"
- Fallback owner name changed from "Developer" to "JP"
- Seed data (`seed.ts`) updated with JP's GitHub URL and new bio
- Seed admin defaults (`seed-admin.ts`) updated with new owner name and bio

Closes #30

## Test plan

- [ ] Visit homepage — verify hero shows updated bio text
- [ ] Clear site config from DB — verify fallback text is the new value proposition
- [ ] Run `npx prisma db seed` — verify seeded config uses new bio

🤖 Generated with [Claude Code](https://claude.com/claude-code)