### PR TITLE
feat: display years of experience on homepage

### DIFF
--- a/app/admin/settings/page.tsx
+++ b/app/admin/settings/page.tsx
@@ -14,6 +14,7 @@ interface SiteConfigForm {
   linkedinUrl: string;
   twitterUrl: string;
   email: string;
+  careerStartDate: string;
 }
 
 const emptyForm: SiteConfigForm = {
@@ -27,6 +28,7 @@ const emptyForm: SiteConfigForm = {
   linkedinUrl: "",
   twitterUrl: "",
   email: "",
+  careerStartDate: "",
 };
 
 export default function AdminSettingsPage() {
@@ -51,6 +53,9 @@ export default function AdminSettingsPage() {
             linkedinUrl: data.linkedinUrl ?? "",
             twitterUrl: data.twitterUrl ?? "",
             email: data.email ?? "",
+            careerStartDate: data.careerStartDate
+              ? new Date(data.careerStartDate).toISOString().split("T")[0]
+              : "",
           });
         }
       })
@@ -157,6 +162,12 @@ export default function AdminSettingsPage() {
             value={form.avatarUrl}
             onChange={(v) => setForm({ ...form, avatarUrl: v })}
             placeholder="https://..."
+          />
+          <FormField
+            label="Career Start Date"
+            value={form.careerStartDate}
+            onChange={(v) => setForm({ ...form, careerStartDate: v })}
+            type="date"
           />
         </fieldset>
 

--- a/app/api/site-config/route.ts
+++ b/app/api/site-config/route.ts
@@ -20,6 +20,7 @@ export async function PUT(request: NextRequest) {
     linkedinUrl,
     twitterUrl,
     email,
+    careerStartDate,
   } = body as {
     siteName?: string;
     siteDescription?: string;
@@ -31,6 +32,7 @@ export async function PUT(request: NextRequest) {
     linkedinUrl?: string;
     twitterUrl?: string;
     email?: string;
+    careerStartDate?: string | null;
   };
 
   const existing = await prisma.siteConfig.findFirst();
@@ -50,6 +52,9 @@ export async function PUT(request: NextRequest) {
         ...(linkedinUrl !== undefined && { linkedinUrl: linkedinUrl || null }),
         ...(twitterUrl !== undefined && { twitterUrl: twitterUrl || null }),
         ...(email !== undefined && { email: email || null }),
+        ...(careerStartDate !== undefined && {
+          careerStartDate: careerStartDate ? new Date(careerStartDate) : null,
+        }),
       },
     });
   } else {
@@ -65,6 +70,7 @@ export async function PUT(request: NextRequest) {
         linkedinUrl: linkedinUrl || null,
         twitterUrl: twitterUrl || null,
         email: email || null,
+        careerStartDate: careerStartDate ? new Date(careerStartDate) : null,
       },
     });
   }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,6 +50,13 @@ export default async function HomePage() {
     config?.ownerBio ??
     "Full-Stack Developer specializing in serverless AWS architecture, React, and TypeScript. I build scalable web applications from cloud infrastructure to polished UI.";
 
+  const yearsOfExperience = config?.careerStartDate
+    ? Math.floor(
+        (Date.now() - new Date(config.careerStartDate).getTime()) /
+          (365.25 * 24 * 60 * 60 * 1000)
+      )
+    : null;
+
   return (
     <>
       {/* Hero */}
@@ -65,6 +72,12 @@ export default async function HomePage() {
             </h1>
             <p className="mt-2 text-xl font-medium text-accent-600 dark:text-accent-400">
               {ownerTitle}
+              {yearsOfExperience !== null && (
+                <span className="text-neutral-400 dark:text-neutral-500">
+                  {" "}
+                  · {yearsOfExperience}+ years
+                </span>
+              )}
             </p>
             <p className="mt-6 text-lg leading-8 text-neutral-600 dark:text-neutral-400">
               {ownerBio}

--- a/prisma/migrations/20260311160724_add_career_start_date/migration.sql
+++ b/prisma/migrations/20260311160724_add_career_start_date/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "site_configs" ADD COLUMN     "careerStartDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model SiteConfig {
   linkedinUrl     String?
   twitterUrl      String?
   email           String?
+  careerStartDate DateTime?
   updatedAt       DateTime @updatedAt
 
   @@map("site_configs")

--- a/prisma/seed-admin.ts
+++ b/prisma/seed-admin.ts
@@ -36,6 +36,7 @@ async function main() {
         ownerName: "JP",
         ownerTitle: "Full-Stack Developer",
         ownerBio: "Full-Stack Developer specializing in serverless AWS architecture, React, and TypeScript. I build scalable web applications from cloud infrastructure to polished UI.",
+        careerStartDate: new Date("2021-01-01"),
       },
     });
     console.log("Created default site config");

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -100,6 +100,7 @@ async function main() {
       linkedinUrl: "https://linkedin.com/in/jp",
       twitterUrl: null,
       email: null,
+      careerStartDate: new Date("2021-01-01"),
     },
   });
   console.log("Created site config");


### PR DESCRIPTION
## Summary

- Adds `careerStartDate` field to `SiteConfig` (Prisma schema + migration)
- Auto-calculates years of experience and displays it next to the owner title in the hero section (e.g., "Full-Stack Developer · 5+ years")
- Editable via Admin > Settings with a date picker input
- Only shown when a career start date is set — graceful fallback when absent

## Test plan

- [ ] Set a career start date in Admin > Settings and verify it saves
- [ ] Confirm the homepage shows "X+ years" next to the title
- [ ] Clear the career start date and confirm the years indicator disappears
- [ ] Verify responsive display on mobile

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)