### PR TITLE
fix: add prisma migrate deploy to Amplify build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,6 +5,7 @@ frontend:
       commands:
         - npm ci
         - npx prisma generate
+        - npx prisma migrate deploy
     build:
       commands:
         - env | grep -E '^(DATABASE_URL|NEXTAUTH_SECRET|NEXTAUTH_URL|S3_)' | sed 's/=.*/=****/' || true

--- a/app/feed.xml/route.ts
+++ b/app/feed.xml/route.ts
@@ -1,3 +1,5 @@
+export const dynamic = "force-dynamic";
+
 import { prisma } from "@/lib/prisma";
 
 function escapeXml(text: string): string {


### PR DESCRIPTION
## Summary

- Adds `npx prisma migrate deploy` to `amplify.yml` preBuild phase so database schema changes are applied automatically on deploy
- Marks `/feed.xml` route as `force-dynamic` so it doesn't query the DB during static page generation at build time

## Root cause

PR #39 added a `careerStartDate` column to the `site_configs` table. The Prisma client was generated with the new field, but the production Neon database never received the migration. When Next.js tried to prerender `/feed.xml` (which calls `prisma.siteConfig.findFirst()`), the query failed because the column didn't exist yet.

## Test plan

- [ ] Merge and verify the Amplify build succeeds
- [ ] Confirm the site loads correctly at production URL
- [ ] Verify `/feed.xml` returns valid RSS XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)