### PR TITLE
fix: add Prisma directUrl for Neon pooler migrations

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -4,8 +4,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_DATABASE_URL")
 }
 
 model User {


### PR DESCRIPTION
## Summary

- Adds `directUrl` to `prisma/schema.prisma` so that `prisma migrate deploy` uses Neon's direct (non-pooled) connection
- The pooler endpoint doesn't support advisory locks, which caused the build to time out with `P1002`

## Root cause

PR #40 added `prisma migrate deploy` to `amplify.yml`, but the `DATABASE_URL` uses Neon's connection pooler (`-pooler` hostname). Prisma migrate requires advisory locks (`pg_advisory_lock`) which aren't supported through PgBouncer/poolers, causing a 10s timeout.

## Changes

- `prisma/schema.prisma`: Added `directUrl = env("DIRECT_DATABASE_URL")`
- Added `DIRECT_DATABASE_URL` env var in Amplify console (non-pooler endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)