### PR TITLE
Rename to DxPress, add CMS feature plans and Amplify blog post

### DIFF
--- a/.claude/commands/publish-post.md
+++ b/.claude/commands/publish-post.md
@@ -1,0 +1,197 @@
+# Publish Blog Post from Markdown
+
+Publish a blog post to DxPress by reading a markdown file and calling the API.
+
+## Instructions
+
+You are a blog publishing assistant. The user will provide a path to a markdown file. Your job is to parse it and create a post via the DxPress API.
+
+### Step 1: Read the markdown file
+
+Read the file the user specified: $ARGUMENTS
+
+If no file path was provided, ask the user for the path to the markdown file.
+
+### Step 2: Parse front matter
+
+The markdown file should have YAML front matter like:
+
+```markdown
+---
+title: "My Blog Post"
+tags: ["nextjs", "typescript"]
+coverImage: "/path/to/image.jpg"
+published: true
+excerpt: "Optional custom excerpt"
+---
+
+Blog content here...
+```
+
+Required fields: `title`
+Optional fields: `tags`, `coverImage`, `published` (default: false), `excerpt`
+
+Use the content after the front matter as the post body. If no `excerpt` is provided, generate one from the first ~160 characters of content (strip markdown formatting).
+
+If the file has no front matter (no `---` delimiters), treat the first `# Heading` as the title and everything after as content.
+
+### Step 3: Load credentials from environment
+
+Read the file `/home/jpdev/source/wordpressClone/.env.publish` to get:
+- `DXPRESS_EMAIL` — admin email
+- `DXPRESS_PASSWORD` — admin password
+- `DXPRESS_API_URL` — base URL (e.g., `http://localhost:3000`)
+
+If `.env.publish` doesn't exist, check `.env.local` for the same variables. If neither exists, ask the user for credentials.
+
+### Step 4: Authenticate with NextAuth
+
+**IMPORTANT**: Use Python `urllib` for the entire auth flow. Curl does not reliably handle NextAuth's cookie/session management. All subsequent API calls should also use the same Python opener with the cookie jar.
+
+```python
+import urllib.request
+import urllib.parse
+import json
+import http.cookiejar
+
+# Setup cookie jar
+cj = http.cookiejar.MozillaCookieJar('/tmp/dxpress-cookies.txt')
+opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+
+# Step 1: Get CSRF token
+req = urllib.request.Request(f"{DXPRESS_API_URL}/api/auth/csrf")
+resp = opener.open(req)
+csrf_token = json.loads(resp.read().decode())['csrfToken']
+
+# Step 2: Sign in
+data = urllib.parse.urlencode({
+    'csrfToken': csrf_token,
+    'email': DXPRESS_EMAIL,
+    'password': DXPRESS_PASSWORD,
+    'redirect': 'false',
+    'json': 'true',
+    'callbackUrl': f'{DXPRESS_API_URL}/admin'
+}).encode('utf-8')
+
+req = urllib.request.Request(
+    f"{DXPRESS_API_URL}/api/auth/callback/credentials",
+    data=data,
+    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+    method='POST'
+)
+resp = opener.open(req)
+
+# Save cookies
+cj.save(ignore_discard=True, ignore_expires=True)
+
+# Step 3: Verify session
+req = urllib.request.Request(f"{DXPRESS_API_URL}/api/auth/session")
+resp = opener.open(req)
+session = json.loads(resp.read().decode())
+# session should contain user data, not {}
+```
+
+After sign-in, reuse the same `opener` for all subsequent requests — it carries the session cookies automatically. For all API calls (tags, upload, post creation), use the Python opener, not curl.
+
+### Step 5: Resolve tags
+
+If the markdown specifies tags, use the Python opener from Step 4:
+
+1. Fetch existing tags:
+```python
+req = urllib.request.Request(f"{DXPRESS_API_URL}/api/tags")
+resp = opener.open(req)
+existing_tags = json.loads(resp.read().decode())
+```
+
+2. For each tag in the front matter, check if it already exists (match by name, case-insensitive).
+
+3. Create any missing tags:
+```python
+payload = json.dumps({"name": "tag-name"}).encode('utf-8')
+req = urllib.request.Request(
+    f"{DXPRESS_API_URL}/api/tags",
+    data=payload,
+    headers={'Content-Type': 'application/json'},
+    method='POST'
+)
+resp = opener.open(req)
+new_tag = json.loads(resp.read().decode())
+```
+
+4. Collect all tag IDs for the post creation step.
+
+### Step 6: Handle cover image (if local file)
+
+If `coverImage` is a local file path (not a URL):
+
+1. Get a presigned upload URL:
+```python
+payload = json.dumps({"filename": "image.jpg", "contentType": "image/jpeg"}).encode('utf-8')
+req = urllib.request.Request(
+    f"{DXPRESS_API_URL}/api/upload",
+    data=payload,
+    headers={'Content-Type': 'application/json'},
+    method='POST'
+)
+resp = opener.open(req)
+upload_data = json.loads(resp.read().decode())
+```
+
+2. Upload the file to the presigned URL (curl is fine for binary uploads):
+```bash
+curl -s -X PUT \
+  -H "Content-Type: image/jpeg" \
+  --data-binary @/path/to/image.jpg \
+  "$PRESIGNED_URL"
+```
+
+3. Use the `publicUrl` from step 1 as the `coverImage` value.
+
+If `coverImage` is already a URL, use it as-is.
+
+### Step 7: Create the post
+
+Use the Python opener from Step 4:
+
+```python
+post_data = {
+    "title": "Post Title",
+    "content": "markdown content...",
+    "excerpt": "excerpt text",
+    "coverImage": "https://...",
+    "published": True,
+    "tagIds": ["id1", "id2"]
+}
+payload = json.dumps(post_data).encode('utf-8')
+req = urllib.request.Request(
+    f"{DXPRESS_API_URL}/api/posts",
+    data=payload,
+    headers={'Content-Type': 'application/json'},
+    method='POST'
+)
+resp = opener.open(req)
+result = json.loads(resp.read().decode())
+```
+
+### Step 8: Report results
+
+After creating the post, display:
+- Post title and slug
+- Published status (draft or published)
+- Tags applied
+- Post URL: `$DXPRESS_API_URL/blog/{slug}`
+- Any errors encountered
+
+### Step 9: Clean up
+
+```bash
+rm -f /tmp/dxpress-cookies.txt
+```
+
+## Error Handling
+
+- If authentication fails, report the error and suggest checking credentials in `.env.publish`
+- If a post with the same title already exists (409), ask the user if they want to update it instead
+- If tag creation fails, continue with available tags and report which ones failed
+- If image upload fails, create the post without the cover image and report the issue

--- a/.claude/commands/publish-project.md
+++ b/.claude/commands/publish-project.md
@@ -1,0 +1,176 @@
+# Publish Project from Markdown
+
+Create a project on DxPress by reading a markdown file and calling the API.
+
+## Instructions
+
+You are a project publishing assistant. The user will provide a path to a markdown file. Your job is to parse it and create a project via the DxPress API.
+
+### Step 1: Read the markdown file
+
+Read the file the user specified: $ARGUMENTS
+
+If no file path was provided, ask the user for the path to the markdown file.
+
+### Step 2: Parse front matter
+
+The markdown file should have YAML front matter like:
+
+```markdown
+---
+title: "My Project"
+description: "A short description of the project"
+techStack: ["Next.js", "TypeScript", "PostgreSQL"]
+githubUrl: "https://github.com/user/repo"
+liveUrl: "https://myproject.com"
+coverImage: "/path/to/image.jpg"
+featured: true
+sortOrder: 1
+---
+
+Full project content in markdown...
+```
+
+Required fields: `title`, `description`
+Optional fields: `techStack` (default: []), `githubUrl`, `liveUrl`, `coverImage`, `featured` (default: false), `sortOrder` (default: 0)
+
+Use the content after the front matter as the project content. If no `description` is provided but content exists, generate a description from the first ~160 characters of content (strip markdown formatting).
+
+If the file has no front matter (no `---` delimiters), treat the first `# Heading` as the title, the first paragraph as the description, and everything after as content.
+
+### Step 3: Load credentials from environment
+
+Read the file `/home/jpdev/source/wordpressClone/.env.publish` to get:
+- `DXPRESS_EMAIL` — admin email
+- `DXPRESS_PASSWORD` — admin password
+- `DXPRESS_API_URL` — base URL (e.g., `http://localhost:3000`)
+
+If `.env.publish` doesn't exist, check `.env.local` for the same variables. If neither exists, ask the user for credentials.
+
+### Step 4: Authenticate with NextAuth
+
+**IMPORTANT**: Use Python `urllib` for the entire auth flow. Curl does not reliably handle NextAuth's cookie/session management. All subsequent API calls should also use the same Python opener with the cookie jar.
+
+```python
+import urllib.request
+import urllib.parse
+import json
+import http.cookiejar
+
+# Setup cookie jar
+cj = http.cookiejar.MozillaCookieJar('/tmp/dxpress-cookies.txt')
+opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+
+# Step 1: Get CSRF token
+req = urllib.request.Request(f"{DXPRESS_API_URL}/api/auth/csrf")
+resp = opener.open(req)
+csrf_token = json.loads(resp.read().decode())['csrfToken']
+
+# Step 2: Sign in
+data = urllib.parse.urlencode({
+    'csrfToken': csrf_token,
+    'email': DXPRESS_EMAIL,
+    'password': DXPRESS_PASSWORD,
+    'redirect': 'false',
+    'json': 'true',
+    'callbackUrl': f'{DXPRESS_API_URL}/admin'
+}).encode('utf-8')
+
+req = urllib.request.Request(
+    f"{DXPRESS_API_URL}/api/auth/callback/credentials",
+    data=data,
+    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+    method='POST'
+)
+resp = opener.open(req)
+
+# Save cookies
+cj.save(ignore_discard=True, ignore_expires=True)
+
+# Step 3: Verify session
+req = urllib.request.Request(f"{DXPRESS_API_URL}/api/auth/session")
+resp = opener.open(req)
+session = json.loads(resp.read().decode())
+# session should contain user data, not {}
+```
+
+After sign-in, reuse the same `opener` for all subsequent requests — it carries the session cookies automatically. For all API calls (upload, project creation), use the Python opener, not curl.
+
+### Step 5: Handle cover image (if local file)
+
+If `coverImage` is a local file path (not a URL), use the Python opener from Step 4:
+
+1. Get a presigned upload URL:
+```python
+payload = json.dumps({"filename": "image.jpg", "contentType": "image/jpeg"}).encode('utf-8')
+req = urllib.request.Request(
+    f"{DXPRESS_API_URL}/api/upload",
+    data=payload,
+    headers={'Content-Type': 'application/json'},
+    method='POST'
+)
+resp = opener.open(req)
+upload_data = json.loads(resp.read().decode())
+```
+
+2. Upload the file to the presigned URL (curl is fine for binary uploads):
+```bash
+curl -s -X PUT \
+  -H "Content-Type: image/jpeg" \
+  --data-binary @/path/to/image.jpg \
+  "$PRESIGNED_URL"
+```
+
+3. Use the `publicUrl` from step 1 as the `coverImage` value.
+
+If `coverImage` is already a URL, use it as-is.
+
+### Step 6: Create the project
+
+Use the Python opener from Step 4:
+
+```python
+project_data = {
+    "title": "Project Title",
+    "description": "Short description",
+    "content": "full markdown content...",
+    "coverImage": "https://...",
+    "githubUrl": "https://github.com/...",
+    "liveUrl": "https://...",
+    "techStack": ["Next.js", "TypeScript"],
+    "featured": True,
+    "sortOrder": 1
+}
+payload = json.dumps(project_data).encode('utf-8')
+req = urllib.request.Request(
+    f"{DXPRESS_API_URL}/api/projects",
+    data=payload,
+    headers={'Content-Type': 'application/json'},
+    method='POST'
+)
+resp = opener.open(req)
+result = json.loads(resp.read().decode())
+```
+
+### Step 7: Report results
+
+After creating the project, display:
+- Project title and slug
+- Description
+- Tech stack
+- Featured status
+- GitHub and live URLs (if provided)
+- Project URL: `$DXPRESS_API_URL/projects/{slug}`
+- Any errors encountered
+
+### Step 8: Clean up
+
+```bash
+rm -f /tmp/dxpress-cookies.txt
+```
+
+## Error Handling
+
+- If authentication fails, report the error and suggest checking credentials in `.env.publish`
+- If a project with the same title already exists (409), ask the user if they want to update it instead
+- If image upload fails, create the project without the cover image and report the issue

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue:*)",
+      "Bash(gh repo:*)",
+      "Bash(git checkout:*)"
+    ]
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Database
-DATABASE_URL="postgresql://inkwell:inkwell_dev@localhost:5432/inkwell?schema=public"
+DATABASE_URL="postgresql://dxpress:dxpress_dev@localhost:5432/dxpress?schema=public"
 
 # NextAuth
 NEXTAUTH_SECRET="generate-a-strong-secret-here"
@@ -7,7 +7,7 @@ NEXTAUTH_URL="http://localhost:3000"
 
 # S3 / MinIO (for image uploads)
 S3_ENDPOINT="http://localhost:9000"
-S3_BUCKET="inkwell-uploads"
+S3_BUCKET="dxpress-uploads"
 S3_ACCESS_KEY="minioadmin"
 S3_SECRET_KEY="minioadmin"
 S3_REGION="us-east-1"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Inkwell** is a modern WordPress clone built with Next.js, TypeScript, PostgreSQL, and Prisma. The project is in early development — see GitHub Issues for the roadmap.
+**DxPress** is a modern WordPress clone built with Next.js, TypeScript, PostgreSQL, and Prisma. The project is in early development — see GitHub Issues for the roadmap.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Inkwell
+# DxPress
 
 A modern WordPress clone built with Next.js, TypeScript, PostgreSQL, and Prisma.
 

--- a/components/admin/MarkdownEditor.tsx
+++ b/components/admin/MarkdownEditor.tsx
@@ -45,7 +45,7 @@ export function MarkdownEditor({
   // Auto-save to localStorage
   useEffect(() => {
     if (value) {
-      localStorage.setItem("inkwell-editor-draft", value);
+      localStorage.setItem("dxpress-editor-draft", value);
     }
   }, [value]);
 

--- a/content/posts/deploying-nextjs-with-amplify-and-prisma.md
+++ b/content/posts/deploying-nextjs-with-amplify-and-prisma.md
@@ -1,0 +1,279 @@
+---
+title: "Deploying a Next.js App with AWS Amplify, Prisma, and Neon PostgreSQL"
+tags: ["aws", "amplify", "prisma", "neon", "nextjs", "devops", "deployment"]
+published: true
+excerpt: "A practical guide to deploying a Next.js + Prisma app on AWS Amplify with Neon PostgreSQL , including the migration pitfalls I hit and how I debugged them."
+---
+
+## Why Amplify?
+
+When I started building **DxPress** a WordPress clone powered by Next.js, Prisma, and PostgreSQL , I needed a hosting solution that could handle server-side rendering without me managing infrastructure. AWS Amplify Gen 2 fits that bill: push your code, and it builds and deploys a full-stack Next.js app with SSR support out of the box.
+
+But getting there wasn't entirely smooth. This post covers how I set up the deployment pipeline, the specific build failures I ran into when adding a new database field , and the kind of issues that don't show up in tutorials but will absolutely bite you in production.
+
+## The Stack
+
+- **Next.js 14+** with the App Router
+- **Prisma ORM** with PostgreSQL
+- **Neon** serverless PostgreSQL (connection pooling via PgBouncer)
+- **AWS Amplify** for CI/CD and hosting
+- **S3** for media uploads
+
+## Setting Up Amplify
+
+### Connecting Your Repo
+
+1. Go to the [AWS Amplify Console](https://console.aws.amazon.com/amplify/)
+2. Click **New app** > **Host web app**
+3. Connect your GitHub repository and select the branch (e.g., `main`)
+4. Amplify auto-detects Next.js and suggests a build config but you'll want to customize it
+
+### The `amplify.yml` Build Spec
+
+Amplify uses an `amplify.yml` file at the root of your project to define build phases. Here's what mine looks like after the fixes I'll describe below:
+
+```yaml
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm ci
+        - npx prisma generate
+        - npx prisma migrate deploy
+    build:
+      commands:
+        - env | grep -E '^(DATABASE_URL|NEXTAUTH_SECRET|NEXTAUTH_URL|S3_)' | sed 's/=.*/=****/' || true
+        - npm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*
+      - .next/cache/**/*
+```
+
+Key points:
+
+- **`npx prisma generate`** generates the Prisma Client so your code can talk to the database
+- **`npx prisma migrate deploy`** applies any pending migrations to the production database , this was the missing piece that caused my first failure
+- The `env | grep ...` line is a debug helper: it logs which env vars are set (values masked) so you can verify your Amplify environment config without leaking secrets
+- Artifacts point to `.next/` because Amplify's Next.js SSR support serves from the built output there
+
+### Environment Variables vs. Secrets in Amplify
+
+Amplify gives you two places to store configuration: **Environment variables** and **Secrets**. The difference matters. Environment variables are stored in plaintext and visible to anyone with console access. Secrets are encrypted with AWS Systems Manager (SSM Parameter Store) and masked in the UI and build logs.
+
+**Rule of thumb**: if the value would be dangerous in the wrong hands: database credentials, API keys, signing secrets then it belongs in Secrets, not Environment variables.
+
+Here's how I split my configuration:
+
+#### Environment Variables (App settings > Environment variables)
+
+These are non-sensitive configuration values that are safe to store in plaintext:
+
+| Variable | Description |
+|----------|-------------|
+| `NEXTAUTH_URL` | Your production URL (e.g., `https://dxpress.example.com`) |
+| `S3_BUCKET` | S3 bucket name for media uploads |
+| `S3_REGION` | AWS region for S3 |
+
+#### Secrets (App settings > Secrets)
+
+These contain credentials, connection strings, and signing keys , anything that could be exploited if exposed:
+
+| Secret | Description |
+|--------|-------------|
+| `DATABASE_URL` | Neon pooled connection string (contains password) |
+| `DIRECT_DATABASE_URL` | Neon direct connection string (contains password) |
+| `NEXTAUTH_SECRET` | Secret key for signing JWT sessions |
+| `S3_ACCESS_KEY` | IAM access key for S3 |
+| `S3_SECRET_KEY` | IAM secret key for S3 |
+
+The distinction between `DATABASE_URL` and `DIRECT_DATABASE_URL` is critical more on that below.
+
+### Moving Secrets Out of Environment Variables
+
+If you originally put sensitive values in Environment variables (like I did), here's how to move them to Secrets and why you should also rotate them.
+
+#### Step 1: Add the values as Secrets
+
+1. In the Amplify Console, navigate to your app
+2. Go to **App settings > Secrets**
+3. Click **Manage secrets**
+4. For each secret, click **Add secret**, enter the key name (e.g., `DATABASE_URL`) and the value
+5. Click **Save**
+
+Amplify stores these in AWS Systems Manager Parameter Store as `SecureString` parameters, encrypted with your account's KMS key.
+
+#### Step 2: Reference secrets in `amplify.yml`
+
+Secrets aren't automatically injected as environment variables the way Environment variables are. You need to explicitly make them available in your build spec. Update your `amplify.yml` to reference them:
+
+```yaml
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - npm ci
+        - npx prisma generate
+        - npx prisma migrate deploy
+    build:
+      commands:
+        - env | grep -E '^(DATABASE_URL|NEXTAUTH_SECRET|NEXTAUTH_URL|S3_)' | sed 's/=.*/=****/' || true
+        - npm run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*
+      - .next/cache/**/*
+```
+
+For Amplify Gen 2 (SSR/Next.js), secrets added through the console are automatically available as environment variables during both the build phase and at runtime. You don't need extra configuration just make sure the secret key names match what your code expects.
+
+#### Step 3: Remove the old Environment variables
+
+1. Go to **App settings > Environment variables**
+2. Delete the entries for `DATABASE_URL`, `DIRECT_DATABASE_URL`, `NEXTAUTH_SECRET`, `S3_ACCESS_KEY`, and `S3_SECRET_KEY`
+3. Leave the non-sensitive variables (`NEXTAUTH_URL`, `S3_BUCKET`, `S3_REGION`) in place
+
+#### Step 4: Rotate your credentials
+
+**This is the step people skip, and it's the most important one.**
+
+If a secret was stored as a plaintext Environment variable even briefly then you should treat it as potentially compromised. Environment variable values are visible in the Amplify Console, may appear in build logs, and are stored without encryption. Anyone with console access could have seen them.
+
+**What to rotate:**
+
+- **Neon database password**: Go to the Neon dashboard, reset the password for your database role, and update both `DATABASE_URL` and `DIRECT_DATABASE_URL` secrets in Amplify with the new connection strings
+- **`NEXTAUTH_SECRET`**: Generate a new random value (e.g., `openssl rand -base64 32`) and update the secret in Amplify. Existing user sessions will be invalidated and users will need to log in again
+- **S3 IAM credentials**: In the AWS IAM Console, go to the IAM user, create a new access key pair, update `S3_ACCESS_KEY` and `S3_SECRET_KEY` in Amplify Secrets, then deactivate and delete the old key pair
+
+After updating, trigger a new build to verify everything still works with the rotated credentials.
+
+#### Step 5: Verify the migration
+
+Trigger a build and check the logs. The masked `env | grep` line in the build spec should still show your variable names (confirming they're set) without values. If any of them are missing, double-check that the secret key names match exactly.
+
+## Checking Builds and Debugging Failures
+
+### Monitoring Builds
+
+When you push to your connected branch, Amplify kicks off a build automatically. To check on it:
+
+1. **Amplify Console**: Navigate to your app, and click on the branch. You'll see a build pipeline with phases: Provision, Build, Deploy, Verify. Each phase expands to show logs.
+2. **Build Logs**: Click into a build and expand the **Build** phase. This is where you'll see your `amplify.yml` commands executing. Errors show up here in red.
+3. **Notifications**: Set up email or Slack notifications under **App settings > Notifications** so you don't have to keep checking manually.
+
+### Common Debugging Steps
+
+When a build fails:
+
+1. **Read the build log from the bottom up**: the actual error is usually near the end, buried under npm output
+2. **Check if it's a build-time vs. runtime issue**: if `npm run build` fails, Next.js might be trying to execute server code at build time (like database queries in pages that should be dynamic)
+3. **Verify environment variables**: the masked `env | grep` line in my build spec helps confirm vars are set. Missing env vars are a silent killer
+4. **Test locally with production build**: run `npm run build` locally with your production env vars to reproduce the issue before pushing another commit
+
+## The Migration That Broke Everything
+
+Here's the real story. I added a "years of experience" feature to the homepage. The implementation was simple:
+
+1. Add a `careerStartDate` field to the `SiteConfig` model in Prisma
+2. Create a migration: `npx prisma migrate dev --name add_career_start_date`
+3. Calculate years dynamically in the homepage component
+4. Add a date picker in the admin settings form
+
+The migration SQL was trivial:
+
+```sql
+ALTER TABLE "site_configs" ADD COLUMN "careerStartDate" TIMESTAMP(3);
+```
+
+Locally, everything worked. I pushed to `main`, Amplify built it, and... the app crashed.
+
+### Failure #1: Migrations Weren't Running
+
+My original `amplify.yml` only had `npx prisma generate` in the preBuild phase. That generates the TypeScript client but **doesn't apply schema changes to the database**. The production Neon database still had the old schema , no `careerStartDate` column , so any query touching that field failed at runtime.
+
+**The fix**: Add `npx prisma migrate deploy` to the preBuild phase. This runs pending migrations against the production database before the build starts.
+
+```yaml
+preBuild:
+  commands:
+    - npm ci
+    - npx prisma generate
+    - npx prisma migrate deploy    # <-- THIS WAS MISSING
+```
+
+### Failure #2: Neon's Connection Pooler Blocks Migrations
+
+After adding `migrate deploy`, the build failed again , but with a different error this time. Prisma's migration engine needs advisory locks to safely coordinate migrations, and **Neon's connection pooler (PgBouncer) doesn't support advisory locks**.
+
+My `DATABASE_URL` pointed to Neon's pooled endpoint (port `5432` with the `-pooler` suffix in the hostname). That's the right connection for runtime queries and it's faster and handles connection scaling. But migrations need a direct connection.
+
+**The fix**: Use Prisma's `directUrl` feature. In `schema.prisma`:
+
+```prisma
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")         // pooled  used at runtime
+  directUrl = env("DIRECT_DATABASE_URL")  // direct  used for migrations
+}
+```
+
+Then in Amplify's environment variables, set `DIRECT_DATABASE_URL` to Neon's direct (non-pooled) connection string. You can find this in the Neon dashboard it's the connection string without `-pooler` in the hostname.
+
+### Failure #3: Build-Time Database Queries
+
+One more surprise: the `npm run build` step was also failing. Next.js was trying to statically generate my RSS feed route (`/feed.xml`), which queries the database for posts. At build time, the database connection worked, but the static generation approach meant Next.js was baking the feed content into the build output instead of generating it on each request.
+
+**The fix**: Mark the route as dynamic:
+
+```typescript
+// app/feed.xml/route.ts
+export const dynamic = "force-dynamic";
+```
+
+This tells Next.js to always render this route at request time, not at build time. Problem solved.
+
+## Lessons Learned
+
+1. **Always run migrations in CI/CD.** `prisma generate` is not enough you need `prisma migrate deploy` to apply schema changes to your production database.
+
+2. **Know your connection types.** If you're using a connection pooler (Neon, Supabase, PgBouncer), you need a separate direct connection for migrations. Prisma's `directUrl` makes this painless.
+
+3. **Watch out for build-time data fetching.** Next.js will try to statically generate pages that fetch data at the top level. If those pages query a database, they'll fail at build time (or worse, succeed with stale data). Use `export const dynamic = "force-dynamic"` for routes that need fresh data.
+
+4. **Use Secrets, not Environment variables, for sensitive values.** Amplify's Environment variables are stored in plaintext. Database passwords, API keys, and signing secrets belong in Amplify Secrets (backed by SSM Parameter Store). If you stored secrets as environment variables, even temporarily, rotate those credentials immediately.
+
+5. **Add observability to your build.** Even a simple `env | grep` command that logs which variables are set (without values) saves time when debugging missing configuration.
+
+6. **Test with `npm run build` locally.** Don't rely on Amplify to be your first feedback loop. Build locally with production env vars to catch issues before they hit your pipeline.
+
+## The Three-Commit Fix
+
+In the end, the full fix was three commits:
+
+1. **Add the feature**: new Prisma field, migration, UI components
+2. **Fix the build pipeline**: add `prisma migrate deploy` to `amplify.yml` and mark `feed.xml` as dynamic
+3. **Fix the connection**: add `directUrl` to the Prisma schema for Neon pooler compatibility
+
+Each commit fixed one layer of the problem. The feature itself was straightforward, it was the deployment pipeline that needed the real engineering.
+
+## Quick Reference: Amplify + Prisma + Neon Checklist
+
+- [ ] `amplify.yml` includes both `prisma generate` AND `prisma migrate deploy`
+- [ ] `DATABASE_URL` env var points to the pooled Neon connection
+- [ ] `DIRECT_DATABASE_URL` env var points to the direct Neon connection
+- [ ] Prisma schema has `directUrl = env("DIRECT_DATABASE_URL")`
+- [ ] Sensitive values (DB passwords, API keys, signing secrets) are stored in **Secrets**, not Environment variables
+- [ ] Credentials that were previously in plaintext Environment variables have been **rotated**
+- [ ] Routes that query the database at the top level are marked `dynamic = "force-dynamic"` if they shouldn't be statically generated
+- [ ] Build logs are checked after each deployment for warnings
+- [ ] `npm run build` succeeds locally before pushing

--- a/content/posts/example-post.md
+++ b/content/posts/example-post.md
@@ -1,0 +1,40 @@
+---
+title: "Getting Started with DxPress"
+tags: ["tutorial", "getting-started"]
+published: false
+excerpt: "Learn how to set up and use DxPress, a modern blogging platform built with Next.js."
+---
+
+## Welcome to DxPress
+
+DxPress is a modern WordPress alternative built with Next.js, TypeScript, and PostgreSQL. This guide will walk you through the basics.
+
+### Features
+
+- Rich markdown editing with live preview
+- Tag-based organization
+- Media library with drag-and-drop uploads
+- Role-based access control
+- SEO-friendly with meta tags and sitemaps
+
+### Writing Your First Post
+
+Create a markdown file with front matter:
+
+```markdown
+---
+title: "My First Post"
+tags: ["blog"]
+published: true
+---
+
+Your content here...
+```
+
+Then publish it using the Claude Code skill:
+
+```
+/publish-post content/posts/my-first-post.md
+```
+
+That's it! Your post is live.

--- a/content/projects/example-project.md
+++ b/content/projects/example-project.md
@@ -1,0 +1,26 @@
+---
+title: "DxPress Test Project"
+description: "A modern WordPress clone built with Next.js, TypeScript, PostgreSQL, and Prisma."
+techStack: ["Next.js", "TypeScript", "PostgreSQL", "Prisma", "Tailwind CSS", "AWS Amplify"]
+githubUrl: "https://github.com/jpdxsoloorg/dxpress"
+liveUrl: "https://www.jpdxsolo.com"
+featured: true
+sortOrder: 1
+---
+
+## Overview
+
+DxPress is a modern blogging and portfolio platform built from scratch as a WordPress alternative. It uses the Next.js App Router with server components, Prisma ORM for database access, and is deployed on AWS Amplify with a Neon serverless PostgreSQL database.
+
+## Key Features
+
+- **Rich Markdown Editing** — Write posts in markdown with live preview and syntax highlighting
+- **Media Library** — Drag-and-drop image uploads to S3-compatible storage
+- **Role-Based Auth** — Admin authentication via NextAuth.js with JWT sessions
+- **SEO Optimized** — Meta tags, sitemaps, and RSS feed generation
+- **Tag System** — Organize posts with tags, create tags on the fly
+- **Project Portfolio** — Showcase projects with tech stack, links, and featured sorting
+
+## Architecture
+
+Built as a monolithic Next.js application using the App Router pattern. API routes handle all backend logic, Prisma manages database access, and S3-compatible storage handles media uploads (MinIO for local dev, AWS S3 in production).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_DB: inkwell
-      POSTGRES_USER: inkwell
-      POSTGRES_PASSWORD: inkwell_dev
+      POSTGRES_DB: dxpress
+      POSTGRES_USER: dxpress
+      POSTGRES_PASSWORD: dxpress_dev
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
@@ -32,8 +32,8 @@ services:
       /bin/sh -c "
       sleep 3;
       mc alias set myminio http://minio:9000 minioadmin minioadmin;
-      mc mb --ignore-existing myminio/inkwell-uploads;
-      mc anonymous set download myminio/inkwell-uploads;
+      mc mb --ignore-existing myminio/dxpress-uploads;
+      mc anonymous set download myminio/dxpress-uploads;
       exit 0;
       "
 

--- a/docs/deployment-aws.md
+++ b/docs/deployment-aws.md
@@ -1,6 +1,6 @@
-# Deploying Inkwell to AWS
+# Deploying DxPress to AWS
 
-This guide covers deploying Inkwell to AWS using ECS Fargate with RDS PostgreSQL and S3 for image storage.
+This guide covers deploying DxPress to AWS using ECS Fargate with RDS PostgreSQL and S3 for image storage.
 
 ## Prerequisites
 
@@ -20,11 +20,11 @@ This guide covers deploying Inkwell to AWS using ECS Fargate with RDS PostgreSQL
 
 ```bash
 aws rds create-db-instance \
-  --db-instance-identifier inkwell-db \
+  --db-instance-identifier dxpress-db \
   --db-instance-class db.t3.micro \
   --engine postgres \
   --engine-version 16 \
-  --master-username inkwell \
+  --master-username dxpress \
   --master-user-password <STRONG_PASSWORD> \
   --allocated-storage 20 \
   --publicly-accessible \
@@ -32,22 +32,22 @@ aws rds create-db-instance \
 ```
 
 Note the endpoint once created. Your DATABASE_URL will be:
-`postgresql://inkwell:<PASSWORD>@<RDS_ENDPOINT>:5432/inkwell?schema=public`
+`postgresql://dxpress:<PASSWORD>@<RDS_ENDPOINT>:5432/dxpress?schema=public`
 
 ## Step 2: Create S3 Bucket
 
 ```bash
-aws s3 mb s3://inkwell-uploads-prod --region us-east-1
+aws s3 mb s3://dxpress-uploads-prod --region us-east-1
 
 # Set bucket policy for public read on uploads
-aws s3api put-bucket-policy --bucket inkwell-uploads-prod --policy '{
+aws s3api put-bucket-policy --bucket dxpress-uploads-prod --policy '{
   "Version": "2012-10-17",
   "Statement": [{
     "Sid": "PublicRead",
     "Effect": "Allow",
     "Principal": "*",
     "Action": "s3:GetObject",
-    "Resource": "arn:aws:s3:::inkwell-uploads-prod/uploads/*"
+    "Resource": "arn:aws:s3:::dxpress-uploads-prod/uploads/*"
   }]
 }'
 ```
@@ -56,17 +56,17 @@ aws s3api put-bucket-policy --bucket inkwell-uploads-prod --policy '{
 
 ```bash
 # Create ECR repository
-aws ecr create-repository --repository-name inkwell
+aws ecr create-repository --repository-name dxpress
 
 # Login to ECR
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com
 
 # Build the image
-docker build -t inkwell .
+docker build -t dxpress .
 
 # Tag and push
-docker tag inkwell:latest <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/inkwell:latest
-docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/inkwell:latest
+docker tag dxpress:latest <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/dxpress:latest
+docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/dxpress:latest
 ```
 
 ## Step 4: Create ECS Task Definition
@@ -77,8 +77,8 @@ Create a task definition with these environment variables:
 |----------|-------|
 | `DATABASE_URL` | Your RDS connection string |
 | `NEXTAUTH_SECRET` | A strong random secret (use `openssl rand -base64 32`) |
-| `NEXTAUTH_URL` | Your production URL (e.g., `https://inkwell.example.com`) |
-| `S3_BUCKET` | `inkwell-uploads-prod` |
+| `NEXTAUTH_URL` | Your production URL (e.g., `https://dxpress.example.com`) |
+| `S3_BUCKET` | `dxpress-uploads-prod` |
 | `S3_REGION` | `us-east-1` |
 | `S3_ACCESS_KEY` | IAM user access key with S3 write permissions |
 | `S3_SECRET_KEY` | IAM user secret key |
@@ -91,11 +91,11 @@ Before starting the service, run Prisma migrations:
 
 ```bash
 # From your local machine with DATABASE_URL pointing to RDS
-DATABASE_URL="postgresql://inkwell:<PASSWORD>@<RDS_ENDPOINT>:5432/inkwell?schema=public" \
+DATABASE_URL="postgresql://dxpress:<PASSWORD>@<RDS_ENDPOINT>:5432/dxpress?schema=public" \
   npx prisma db push
 
 # Seed the admin user
-DATABASE_URL="postgresql://inkwell:<PASSWORD>@<RDS_ENDPOINT>:5432/inkwell?schema=public" \
+DATABASE_URL="postgresql://dxpress:<PASSWORD>@<RDS_ENDPOINT>:5432/dxpress?schema=public" \
   npx ts-node --compiler-options '{"module":"CommonJS"}' prisma/seed-admin.ts
 ```
 
@@ -118,10 +118,10 @@ Use ACM to create a certificate for your domain and attach it to the ALB listene
 ## Environment Variables Summary
 
 ```env
-DATABASE_URL=postgresql://inkwell:<PASSWORD>@<RDS_ENDPOINT>:5432/inkwell?schema=public
+DATABASE_URL=postgresql://dxpress:<PASSWORD>@<RDS_ENDPOINT>:5432/dxpress?schema=public
 NEXTAUTH_SECRET=<RANDOM_SECRET>
 NEXTAUTH_URL=https://your-domain.com
-S3_BUCKET=inkwell-uploads-prod
+S3_BUCKET=dxpress-uploads-prod
 S3_REGION=us-east-1
 S3_ACCESS_KEY=<IAM_ACCESS_KEY>
 S3_SECRET_KEY=<IAM_SECRET_KEY>
@@ -132,8 +132,8 @@ S3_SECRET_KEY=<IAM_SECRET_KEY>
 To deploy updates:
 
 ```bash
-docker build -t inkwell .
-docker tag inkwell:latest <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/inkwell:latest
-docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/inkwell:latest
-aws ecs update-service --cluster inkwell --service inkwell --force-new-deployment
+docker build -t dxpress .
+docker tag dxpress:latest <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/dxpress:latest
+docker push <ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/dxpress:latest
+aws ecs update-service --cluster dxpress --service dxpress --force-new-deployment
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inkwell",
+  "name": "dxpress",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -22,7 +22,7 @@ async function main() {
   const hashedPassword = await bcrypt.hash("admin123", 12);
   const user = await prisma.user.create({
     data: {
-      email: "admin@inkwell.dev",
+      email: "admin@dxpress.dev",
       password: hashedPassword,
       name: "Alex Morgan",
       role: "ADMIN",

--- a/prisma/seed/projects.ts
+++ b/prisma/seed/projects.ts
@@ -1,16 +1,16 @@
 export const projectsData = [
   {
-    title: "Inkwell",
-    slug: "inkwell",
+    title: "DxPress",
+    slug: "dxpress",
     description: "A modern developer portfolio and blog platform built with Next.js 14, Prisma, and PostgreSQL. Features MDX rendering with syntax highlighting, dark mode, and a full admin panel.",
     techStack: ["Next.js", "TypeScript", "Prisma", "PostgreSQL", "Tailwind CSS"],
-    githubUrl: "https://github.com/username/inkwell",
-    liveUrl: "https://inkwell.dev",
+    githubUrl: "https://github.com/username/dxpress",
+    liveUrl: "https://dxpress.dev",
     featured: true,
     sortOrder: 1,
     content: `## Overview
 
-Inkwell is a full-featured developer portfolio platform that I built to showcase my work and writing. It features server-side rendering, MDX blog posts with syntax highlighting, and a complete admin panel for content management.
+DxPress is a full-featured developer portfolio platform that I built to showcase my work and writing. It features server-side rendering, MDX blog posts with syntax highlighting, and a complete admin panel for content management.
 
 ## Key Features
 

--- a/prompts/004-categories-taxonomies.md
+++ b/prompts/004-categories-taxonomies.md
@@ -1,0 +1,92 @@
+<objective>
+Add hierarchical categories to DxPress's content system — the most fundamental taxonomy feature that WordPress, Joomla, and Drupal all provide. Posts currently only have flat tags. Categories provide hierarchical organization (e.g., Technology > Frontend > React) that helps both content creators organize and readers navigate.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- Posts have flat tags via a many-to-many relation (Post ↔ Tag)
+- No category model exists in the Prisma schema
+- No category UI in admin or public pages
+- Blog listing at /blog has no category filtering
+
+Comparable CMS features:
+- **WordPress**: Categories are hierarchical (parent/child), every post must have at least one (defaults to "Uncategorized"). Tags are flat. Both are taxonomies.
+- **Joomla**: Uses hierarchical categories as the primary organizer. Articles must belong to exactly one category.
+- **Drupal**: Taxonomy system with vocabularies (category groups) and terms (individual categories), fully hierarchical.
+
+For DxPress, we want WordPress-style categories: hierarchical, optional (not required), multiple per post.
+
+@prisma/schema.prisma
+@app/api/posts/route.ts
+@app/blog/page.tsx
+@app/admin/posts/new/page.tsx
+</context>
+
+<requirements>
+1. **Prisma schema**: Add a `Category` model with self-referencing parent/child relationship:
+   - id, name, slug (unique), description (optional), parentId (nullable FK to self), sortOrder
+   - Many-to-many relation with Post (like tags)
+   - Index on slug and parentId
+
+2. **API routes** (`app/api/categories/`):
+   - GET /api/categories — return all categories as a nested tree structure
+   - POST /api/categories — create category (auth required)
+   - PUT /api/categories/[id] — update category (auth required)
+   - DELETE /api/categories/[id] — delete category, fail if has children or posts assigned (auth required)
+
+3. **Admin UI** (`app/admin/categories/page.tsx`):
+   - List categories in tree view showing hierarchy
+   - Create/edit form with name, slug (auto-generated from name), description, parent category dropdown
+   - Delete with confirmation (blocked if has children)
+
+4. **Post editor integration**:
+   - Add category selector to post create/edit forms (multi-select with hierarchy shown)
+   - Update post API to accept categoryIds
+
+5. **Public blog integration**:
+   - Add category filter sidebar/nav to /blog
+   - Category archive page at /blog/category/[slug] showing posts in that category (and child categories)
+   - Show categories on post cards and post detail pages
+
+6. **Migration**: Create Prisma migration for the new models and relations
+</requirements>
+
+<implementation>
+- Use Prisma's self-relation pattern for parent/child: `parent Category? @relation("CategoryChildren", fields: [parentId], references: [id])` and `children Category[] @relation("CategoryChildren")`
+- Build the tree structure server-side in the GET endpoint, not client-side
+- Reuse the existing tag styling patterns for category display on public pages
+- Category slugs should be unique globally (not scoped to parent) for simple URL routing
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/schema.prisma` — add Category model and Post relation
+- `prisma/migrations/*` — new migration
+- `app/api/categories/route.ts` — GET all, POST create
+- `app/api/categories/[id]/route.ts` — PUT update, DELETE
+- `app/api/posts/route.ts` — update to handle categoryIds
+- `app/admin/categories/page.tsx` — admin category management
+- `app/admin/posts/new/page.tsx` — add category selector
+- `app/admin/posts/[id]/edit/page.tsx` — add category selector
+- `app/blog/page.tsx` — add category filter
+- `app/blog/category/[slug]/page.tsx` — category archive page
+</output>
+
+<verification>
+- Categories can be created with parent/child hierarchy (3 levels deep)
+- Posts can be assigned to multiple categories
+- Blog filters by category and shows posts from child categories
+- Deleting a category with children is blocked
+- Category slugs are unique and URL-safe
+- Admin UI shows tree structure clearly
+</verification>
+
+<success_criteria>
+- Category CRUD works end-to-end (admin create → public display)
+- Hierarchical tree renders correctly in admin and public views
+- Post editor allows category assignment
+- /blog/category/[slug] returns correct filtered posts
+- Prisma migration applies cleanly
+</success_criteria>

--- a/prompts/005-comments-system.md
+++ b/prompts/005-comments-system.md
@@ -1,0 +1,104 @@
+<objective>
+Add a comments system to DxPress blog posts. Comments are a core CMS feature present in WordPress, Joomla, and Drupal. They enable reader engagement and discussion on published content.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- Posts have no comments model or UI
+- No public-facing interactivity beyond reading
+- Auth exists only for admin (NextAuth with single ADMIN role)
+
+Comparable CMS features:
+- **WordPress**: Built-in comments with threading (nested replies), moderation queue (pending/approved/spam/trash), guest commenting (name + email), and Gravatar integration. Admin can enable/disable per post.
+- **Joomla**: Comments not built-in (relies on extensions like JComments), but the data model supports it.
+- **Drupal**: Comments as a field type — can be added to any content type, supports threading, moderation, and anonymous commenting.
+
+For DxPress, we want WordPress-style comments: threaded, moderated, guest commenting with name/email (no account required), admin approval workflow.
+
+@prisma/schema.prisma
+@app/blog/[slug]/page.tsx
+@app/api/posts/route.ts
+</context>
+
+<requirements>
+1. **Prisma schema**: Add a `Comment` model:
+   - id, content (text), authorName, authorEmail, postId (FK to Post), parentId (nullable FK to self for threading)
+   - status enum: PENDING, APPROVED, SPAM, TRASH (default PENDING)
+   - createdAt, updatedAt
+   - Relation to Post (many comments per post)
+   - Self-relation for threaded replies
+
+2. **Post schema update**: Add `commentsEnabled` boolean field to Post (default true)
+
+3. **Public API routes**:
+   - GET /api/posts/[id]/comments — return approved comments as threaded tree
+   - POST /api/posts/[id]/comments — submit comment (no auth, but requires name + email + content; honeypot field for basic spam prevention)
+
+4. **Admin API routes**:
+   - GET /api/admin/comments — list all comments with filters (status, post) with pagination
+   - PUT /api/admin/comments/[id] — update status (approve, spam, trash) (auth required)
+   - DELETE /api/admin/comments/[id] — permanently delete (auth required)
+
+5. **Public UI** (blog post page):
+   - Comment section below post content (only if commentsEnabled)
+   - Display approved comments with threading (max 3 levels deep)
+   - Comment submission form: name, email (not displayed publicly), comment text
+   - Show comment count on post cards in blog listing
+   - Success message after submission: "Comment submitted for moderation"
+
+6. **Admin UI**:
+   - Comments management page (`app/admin/comments/page.tsx`)
+   - Filter by status (pending/approved/spam/trash)
+   - Bulk actions: approve, spam, trash selected comments
+   - Show which post each comment belongs to
+   - Toggle commentsEnabled per post in post editor
+   - Dashboard: pending comment count indicator
+
+7. **Spam prevention**:
+   - Honeypot hidden field (if filled, reject silently)
+   - Rate limiting: max 3 comments per email per hour
+   - Basic content validation (not empty, reasonable length 1-5000 chars)
+</requirements>
+
+<implementation>
+- Thread comments server-side: fetch flat, build tree in the GET endpoint
+- Use optimistic UI for comment submission (show "pending moderation" immediately)
+- Email is collected for admin reference and gravatar-style avatar potential, but never shown publicly
+- Honeypot field should be visually hidden via CSS (not display:none, which bots detect)
+- Rate limiting can use a simple in-memory check or a DynamoDB/Prisma count query
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/schema.prisma` — add Comment model, CommentStatus enum, Post.commentsEnabled field
+- `prisma/migrations/*` — new migration
+- `app/api/posts/[id]/comments/route.ts` — public GET/POST
+- `app/api/admin/comments/route.ts` — admin list with filters
+- `app/api/admin/comments/[id]/route.ts` — admin PUT/DELETE
+- `app/blog/[slug]/page.tsx` — add comment section
+- `app/blog/[slug]/CommentSection.tsx` — client component for comments UI
+- `app/blog/[slug]/CommentForm.tsx` — client component for submission form
+- `app/admin/comments/page.tsx` — admin comment moderation
+- `app/admin/posts/new/page.tsx` — add commentsEnabled toggle
+- `app/admin/posts/[id]/edit/page.tsx` — add commentsEnabled toggle
+</output>
+
+<verification>
+- Guest can submit a comment (name + email + text) without logging in
+- Comment appears as "pending" in admin, not on public page
+- Admin can approve → comment appears publicly
+- Threaded replies render with visual indentation (max 3 levels)
+- Honeypot field rejects bot submissions
+- commentsEnabled toggle hides/shows comment section per post
+- Comment count shows on blog listing cards
+</verification>
+
+<success_criteria>
+- Full comment lifecycle works: submit → moderate → display (or reject)
+- Threading renders correctly up to 3 levels
+- Spam prevention catches basic bot submissions
+- Admin can efficiently moderate with bulk actions
+- No authenticated account needed for commenting
+</success_criteria>

--- a/prompts/006-static-pages-menus.md
+++ b/prompts/006-static-pages-menus.md
@@ -1,0 +1,105 @@
+<objective>
+Add dynamic static pages and navigation menu management to DxPress. Currently, pages like About are hardcoded React components. WordPress, Joomla, and Drupal all let admins create arbitrary pages and organize them into navigation menus without touching code.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- /about is a hardcoded page component
+- No dynamic page creation capability
+- Navigation links are hardcoded in the layout
+- No menu management system
+
+Comparable CMS features:
+- **WordPress**: Pages are a content type (like posts but not in the blog feed). Menus are managed via Appearance > Menus — drag-and-drop ordering, nested items, can link to pages/categories/custom URLs. Multiple menu locations (header, footer, sidebar).
+- **Joomla**: Menu Manager creates menus with items pointing to articles, categories, components, or external URLs. Each menu item has a menu type (single article, category blog, etc.).
+- **Drupal**: Menu system with blocks. Pages created as "Basic page" content type. Menus support hierarchy and multiple locations.
+
+For DxPress, we want: dynamic pages with rich text content (like posts), and a menu management system for header/footer navigation.
+
+@prisma/schema.prisma
+@app/layout.tsx
+@app/about/page.tsx
+</context>
+
+<requirements>
+1. **Prisma schema**: Add a `Page` model:
+   - id, title, slug (unique), content (rich text), metaTitle, metaDescription
+   - published (boolean, default false), sortOrder
+   - createdAt, updatedAt
+
+   Add a `Menu` model:
+   - id, name (e.g., "Header", "Footer"), location (enum: HEADER, FOOTER)
+
+   Add a `MenuItem` model:
+   - id, label, url (for external links), pageId (nullable FK to Page, for internal links), menuId (FK to Menu)
+   - parentId (nullable FK to self for dropdowns), sortOrder
+   - openInNewTab (boolean, default false)
+
+2. **Page API routes** (`app/api/pages/`):
+   - GET /api/pages — list all pages (public: published only)
+   - GET /api/pages/[slug] — get page by slug
+   - POST /api/pages — create page (auth required)
+   - PUT /api/pages/[id] — update page (auth required)
+   - DELETE /api/pages/[id] — delete page (auth required)
+
+3. **Menu API routes** (`app/api/menus/`):
+   - GET /api/menus — return all menus with items (nested tree)
+   - GET /api/menus/[location] — get menu by location (e.g., /api/menus/header)
+   - PUT /api/menus/[id] — update menu items and order (auth required)
+
+4. **Admin UI**:
+   - Pages management (`app/admin/pages/page.tsx`): list, create, edit, delete pages
+   - Page editor: title, slug, rich text content, meta title/description, publish toggle
+   - Menu management (`app/admin/menus/page.tsx`): drag-and-drop reordering of menu items, add page links / custom URLs, nest items for dropdowns
+
+5. **Public rendering**:
+   - Dynamic page route at `/[slug]` — catches page slugs, renders content
+   - Must not conflict with existing routes (/blog, /about, /projects, /resume, /admin)
+   - Header navigation reads from the HEADER menu instead of hardcoded links
+   - Footer navigation reads from the FOOTER menu
+   - Migrate existing /about content to a database Page record via seed/migration
+
+6. **SEO**: Pages should render metaTitle and metaDescription in head tags
+</requirements>
+
+<implementation>
+- For the catch-all `/[slug]` page route, use Next.js dynamic routing with a check: if slug matches a known static route, return notFound(). Otherwise query the Page table.
+- Menu items should be fetched in the root layout and passed down (or cached with Next.js fetch caching)
+- For menu drag-and-drop in admin, a simple sortable list is fine — no need for a complex DnD library. A move-up/move-down button approach works too.
+- Seed the default Header menu with: Home, Blog, Projects, About, Resume
+- Seed the default Footer menu with: Home, Blog
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/schema.prisma` — add Page, Menu, MenuItem models
+- `prisma/migrations/*` — new migration
+- `app/api/pages/route.ts` — GET list, POST create
+- `app/api/pages/[slug]/route.ts` — GET by slug, PUT, DELETE
+- `app/api/menus/route.ts` — GET all menus
+- `app/api/menus/[location]/route.ts` — GET by location, PUT update
+- `app/admin/pages/page.tsx` — page management
+- `app/admin/pages/new/page.tsx` — create page
+- `app/admin/pages/[id]/edit/page.tsx` — edit page
+- `app/admin/menus/page.tsx` — menu management
+- `app/[slug]/page.tsx` — dynamic public page rendering
+- `app/layout.tsx` — update to read nav from menu API
+</output>
+
+<verification>
+- Admin can create a new page, publish it, and it's accessible at /[slug]
+- Dynamic pages don't conflict with /blog, /projects, /admin, etc.
+- Header navigation reflects the HEADER menu configuration
+- Menu items can be reordered and nested (1 level for dropdowns)
+- Existing /about content works as a dynamic page
+- Page SEO meta tags render correctly
+</verification>
+
+<success_criteria>
+- Page CRUD works end-to-end
+- Menu management updates header/footer navigation without code changes
+- Dynamic slug routing works without conflicts
+- SEO meta renders on dynamic pages
+</success_criteria>

--- a/prompts/007-multi-user-roles.md
+++ b/prompts/007-multi-user-roles.md
@@ -1,0 +1,109 @@
+<objective>
+Expand DxPress's user system from a single admin to a multi-user platform with role-based access control. Every major CMS supports multiple user roles — this is foundational for any team-managed content site.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- Single `User` model with only `ADMIN` role
+- One admin account, no user registration or invitation system
+- All admin routes are all-or-nothing: you're admin or you're not
+- NextAuth configured with Credentials provider, JWT sessions
+
+Comparable CMS features:
+- **WordPress**: 5 default roles — Administrator, Editor, Author, Contributor, Subscriber. Each has specific capabilities (publish_posts, edit_others_posts, manage_categories, etc.). Admins can create users and assign roles.
+- **Joomla**: Flexible ACL with groups (Super Users, Administrators, Managers, Publishers, Editors, Authors, Registered). Permission inheritance through group hierarchy.
+- **Drupal**: Role-based permissions. Default roles: Anonymous, Authenticated, Administrator. Custom roles can be created with granular permissions.
+
+For DxPress, implement WordPress-style roles: Admin, Editor, Author with clear capability boundaries.
+
+@prisma/schema.prisma
+@app/api/auth/[...nextauth]/route.ts
+@app/admin/layout.tsx
+</context>
+
+<requirements>
+1. **Role definitions**:
+   - **ADMIN**: Full access — manage all content, users, settings, categories, menus, comments
+   - **EDITOR**: Manage all content (own + others' posts/pages), manage categories, moderate comments. Cannot manage users or site settings.
+   - **AUTHOR**: Create and manage own posts only. Cannot edit others' content, manage categories, or access settings.
+
+2. **Prisma schema updates**:
+   - Expand Role enum: ADMIN, EDITOR, AUTHOR
+   - Add to User: avatarUrl, bio, lastLoginAt
+
+3. **User management API** (`app/api/admin/users/`):
+   - GET /api/admin/users — list all users (admin only)
+   - POST /api/admin/users — create/invite user with role (admin only)
+   - PUT /api/admin/users/[id] — update user role, name, email (admin only; cannot demote self)
+   - DELETE /api/admin/users/[id] — delete user (admin only; cannot delete self; reassign content to admin)
+
+4. **Auth updates**:
+   - Include role in JWT session token
+   - Update NextAuth callbacks to include role in session
+   - Create a `usePermissions` hook or utility for capability checks
+
+5. **Permission middleware**:
+   - Create a reusable `requireRole(roles: Role[])` wrapper for API routes
+   - Posts API: Authors can only GET/PUT/DELETE their own posts; Editors can manage all posts
+   - Categories/Menus/Settings/Users: Admin only (Settings, Users), Admin + Editor (Categories, Menus, Comments)
+
+6. **Admin UI updates**:
+   - User management page (`app/admin/users/page.tsx`): list users, create, edit role, delete (admin only)
+   - Conditionally show/hide admin nav items based on role (Authors don't see Settings, Users, etc.)
+   - Post list: Authors see only their posts; Editors/Admins see all
+   - Show current user info in admin header/sidebar
+
+7. **Author profile**: Public author page at `/author/[slug]` showing author name, bio, and their published posts
+</requirements>
+
+<implementation>
+- Use NextAuth's JWT callback to embed role in the token, and session callback to expose it
+- Permission utility should be a simple function, not a complex RBAC library:
+  ```typescript
+  function canEditPost(session: Session, post: Post): boolean {
+    return session.user.role === 'ADMIN' || session.user.role === 'EDITOR' || post.authorId === session.user.id;
+  }
+  ```
+- For the API middleware, a higher-order function pattern works well:
+  ```typescript
+  export const withRole = (roles: Role[], handler: Handler) => async (req, ctx) => { ... }
+  ```
+- User creation should use bcrypt for password hashing (already in dependencies)
+- When deleting a user, reassign their posts to the admin performing the deletion
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/schema.prisma` — expand Role enum, update User model
+- `prisma/migrations/*` — new migration
+- `lib/permissions.ts` — role checking utilities
+- `lib/auth.ts` — requireRole middleware
+- `app/api/auth/[...nextauth]/route.ts` — update JWT/session callbacks
+- `app/api/admin/users/route.ts` — GET list, POST create
+- `app/api/admin/users/[id]/route.ts` — PUT update, DELETE
+- `app/api/posts/route.ts` — add role-based filtering
+- `app/api/posts/[id]/route.ts` — add ownership checks
+- `app/admin/users/page.tsx` — user management UI
+- `app/admin/layout.tsx` — conditional nav based on role
+- `app/author/[slug]/page.tsx` — public author profile
+</output>
+
+<verification>
+- Admin can create users with Editor and Author roles
+- Editor can edit any post but cannot access Settings or Users
+- Author can only see and edit their own posts
+- Admin nav shows/hides items based on role
+- Cannot demote or delete yourself as admin
+- Deleting a user reassigns their content
+- Author profile page shows correct posts
+</verification>
+
+<success_criteria>
+- Three distinct roles with correct capability boundaries
+- API routes enforce permissions (not just UI hiding)
+- User CRUD works for admin
+- Post ownership enforced for Authors
+- JWT sessions include role information
+</success_criteria>

--- a/prompts/008-media-library.md
+++ b/prompts/008-media-library.md
@@ -1,0 +1,107 @@
+<objective>
+Build a browsable media library for DxPress. Currently, image uploads go to S3 but there's no way to browse, search, or reuse previously uploaded media. Every major CMS has a media library — it's essential for content management at scale.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- Images upload to S3 via presigned URLs (`app/api/upload/route.ts`)
+- No record of uploaded files in the database
+- No way to browse or reuse previously uploaded images
+- Cover images are set per-post but the URL is just a string field
+
+Comparable CMS features:
+- **WordPress**: Media Library with grid/list views, search, filter by type/date, image editing (crop/resize), bulk upload, drag-and-drop. Every upload tracked in `wp_posts` as an "attachment" post type. Insert from Media Library when editing posts.
+- **Joomla**: Media Manager with folder-based organization, upload, preview, and insert into articles.
+- **Drupal**: Media module with reusable media entities, media browser for inserting into content, image styles (auto-resize).
+
+For DxPress, we want: tracked uploads with metadata, browsable library with grid view, search, and an "insert from library" picker in the post editor.
+
+@prisma/schema.prisma
+@app/api/upload/route.ts
+@app/admin/posts/new/page.tsx
+</context>
+
+<requirements>
+1. **Prisma schema**: Add a `Media` model:
+   - id, filename (original name), key (S3 key), url (public URL), mimeType, size (bytes)
+   - width, height (for images — extracted during upload)
+   - altText (user-editable), caption (optional)
+   - uploadedById (FK to User)
+   - createdAt
+
+2. **API routes** (`app/api/media/`):
+   - GET /api/media — list media with pagination, search (by filename/altText), filter by type (image/document/video)
+   - POST /api/media — upload file (handles presigned URL generation + creates Media record)
+   - PUT /api/media/[id] — update altText, caption (auth required)
+   - DELETE /api/media/[id] — delete from S3 and database (auth required)
+   - POST /api/media/bulk — bulk upload multiple files
+
+3. **Admin UI** (`app/admin/media/page.tsx`):
+   - Grid view showing image thumbnails (with fallback icons for non-image types)
+   - List view toggle (table with filename, type, size, date, uploader)
+   - Search bar (searches filename and altText)
+   - Filter by file type (Images, Documents, Videos, All)
+   - Upload zone: drag-and-drop area + file picker button, supports multiple files
+   - Click on media item to view details: preview, edit altText/caption, copy URL, delete
+   - Bulk select and delete
+
+4. **Media picker component** (reusable):
+   - Modal that opens the media library for selection
+   - Shows existing uploads in grid with search/filter
+   - "Upload new" tab within the picker
+   - Returns selected media URL(s) to the calling component
+   - Use this picker for: post cover image, page cover image, any future image fields
+
+5. **Post editor integration**:
+   - Replace direct URL input for cover image with the media picker
+   - Add "Insert image" button in the content editor that opens the media picker and inserts markdown image syntax
+
+6. **Upload improvements**:
+   - Show upload progress bar for each file
+   - Validate file type and size before upload (max 10MB images, 50MB documents)
+   - Generate unique S3 keys to avoid collisions (prefix with date + random)
+</requirements>
+
+<implementation>
+- Store the S3 key separately from the full URL so the URL can be reconstructed if the bucket/CDN changes
+- For image dimensions, use the browser's Image API on the client side before upload, then send width/height to the API
+- The media picker should be a client component with its own state management (not coupled to any specific page)
+- Pagination: cursor-based using createdAt for efficient DynamoDB-style queries
+- For the grid view, use CSS grid with consistent thumbnail sizing (cover/contain based on aspect ratio)
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/schema.prisma` — add Media model
+- `prisma/migrations/*` — new migration
+- `app/api/media/route.ts` — GET list, POST upload
+- `app/api/media/[id]/route.ts` — PUT update, DELETE
+- `app/api/media/bulk/route.ts` — bulk upload
+- `app/admin/media/page.tsx` — media library page
+- `components/MediaPicker.tsx` — reusable media picker modal
+- `components/MediaGrid.tsx` — grid display component
+- `components/UploadZone.tsx` — drag-and-drop upload component
+- `app/admin/posts/new/page.tsx` — integrate media picker for cover image
+- `app/admin/posts/[id]/edit/page.tsx` — integrate media picker for cover image
+</output>
+
+<verification>
+- Upload an image → appears in media library with correct metadata
+- Search by filename finds the uploaded image
+- Media picker modal opens, shows library, allows selection
+- Selected image URL populates the cover image field
+- Delete removes from both S3 and database
+- Bulk upload handles multiple files with progress indicators
+- Non-image files show appropriate icons in grid view
+</verification>
+
+<success_criteria>
+- All uploads tracked in database with metadata
+- Browsable grid/list view with search and type filters
+- Media picker works as a reusable component
+- Post editor uses picker instead of raw URL input
+- Upload progress shown for each file
+- Delete cleans up both database and S3
+</success_criteria>

--- a/prompts/009-search-functionality.md
+++ b/prompts/009-search-functionality.md
@@ -1,0 +1,103 @@
+<objective>
+Add full-text search to DxPress. Search is a fundamental CMS feature — WordPress, Joomla, and Drupal all include built-in search. Without it, readers have no way to find content beyond browsing.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- No search functionality exists (no search bar, no search API, no search results page)
+- Blog listing shows all published posts with no filtering beyond tags
+- PostgreSQL is the database (Neon serverless) — it has built-in full-text search capabilities
+
+Comparable CMS features:
+- **WordPress**: Built-in search with `?s=` query parameter. Searches post title, content, and excerpt. Search widget for sidebar. Many sites enhance with plugins (Relevanssi, ElasticSearch).
+- **Joomla**: Smart Search component with indexing, filters by category/type/date, autocomplete suggestions.
+- **Drupal**: Core Search module with indexing. Views integration for custom search pages.
+
+For DxPress, we want PostgreSQL full-text search (no external service needed): search bar in header, search results page, searches across posts, pages, and projects.
+
+@prisma/schema.prisma
+@app/layout.tsx
+@app/blog/page.tsx
+</context>
+
+<requirements>
+1. **Search API** (`app/api/search/route.ts`):
+   - GET /api/search?q=query&type=all|posts|pages|projects&page=1&limit=10
+   - Use PostgreSQL full-text search (`to_tsvector` / `to_tsquery`) via Prisma raw queries
+   - Search fields: title, content, excerpt (for posts); title, content (for pages); title, description (for projects)
+   - Return results ranked by relevance with highlighted matching snippets
+   - Only return published content
+   - Handle empty/short queries gracefully (min 2 characters)
+
+2. **Search bar component** (`components/SearchBar.tsx`):
+   - Appears in the site header (all pages)
+   - Expandable: icon that expands to input on click (mobile-friendly)
+   - Debounced input (300ms) with loading indicator
+   - Quick results dropdown showing top 5 results as user types
+   - "View all results" link to full search results page
+   - Keyboard shortcut: Cmd/Ctrl+K opens search (like Spotlight/Algolia)
+
+3. **Search results page** (`app/search/page.tsx`):
+   - Full search results with query in URL: /search?q=query
+   - Filter tabs: All, Posts, Pages, Projects
+   - Each result shows: title (linked), snippet with highlighted match, content type badge, date
+   - Pagination for results
+   - "No results found" state with suggestions
+   - Preserves query in search input
+
+4. **SEO considerations**:
+   - Search results page should have `noindex` meta tag (search results shouldn't be indexed)
+   - Search queries should use URL query params (not hash) for shareability
+
+5. **Performance**:
+   - Add PostgreSQL GIN index on tsvector columns for fast full-text search
+   - Cache search results briefly (revalidate: 60) for repeated queries
+   - Debounce on client, rate-limit on server (10 requests/minute per IP)
+</requirements>
+
+<implementation>
+- Use Prisma's `$queryRaw` for full-text search since Prisma doesn't natively support tsvector:
+  ```sql
+  SELECT id, title, ts_headline('english', content, query) as snippet,
+         ts_rank(to_tsvector('english', title || ' ' || content), query) as rank
+  FROM posts, to_tsquery('english', $1) query
+  WHERE to_tsvector('english', title || ' ' || content) @@ query
+    AND published = true
+  ORDER BY rank DESC
+  ```
+- Create the GIN index via a Prisma migration using raw SQL
+- The search bar should be a client component ("use client") with useState for the dropdown
+- Use `useRouter` and `useSearchParams` for the results page to handle URL state
+- ts_headline provides snippets with highlighted matches — return these as HTML and render with dangerouslySetInnerHTML (content is from our own database, safe)
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/migrations/*` — add GIN indexes for full-text search
+- `app/api/search/route.ts` — search endpoint with full-text query
+- `components/SearchBar.tsx` — expandable search bar with quick results
+- `app/search/page.tsx` — full search results page
+- `app/layout.tsx` — add SearchBar to header
+</output>
+
+<verification>
+- Search for a word in a post title → post appears in results
+- Search for content within a post body → post appears with snippet
+- Quick results dropdown shows top 5 as you type
+- Filter tabs correctly filter by content type
+- Cmd/Ctrl+K opens search bar
+- Empty/short queries handled gracefully
+- Search results page is noindex
+- GIN indexes exist in the database
+</verification>
+
+<success_criteria>
+- Full-text search works across posts, pages, and projects
+- Search bar accessible from every page via header
+- Quick results dropdown provides instant feedback
+- Results ranked by relevance with highlighted snippets
+- Search is fast (<200ms for typical queries with GIN indexes)
+- Keyboard shortcut works
+</success_criteria>

--- a/prompts/010-post-revisions-scheduling.md
+++ b/prompts/010-post-revisions-scheduling.md
@@ -1,0 +1,117 @@
+<objective>
+Add post revision history and scheduled publishing to DxPress. These are editorial workflow features that WordPress and Drupal include by default — they protect against accidental content loss and enable planned content calendars.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- Posts can be saved as draft or published immediately
+- No version history — edits overwrite the previous version permanently
+- No scheduling — published means "now", no future date publishing
+- publishedAt field exists on Post but is set at publish time, not user-configurable
+
+Comparable CMS features:
+- **WordPress**: Auto-saves every 60 seconds. Full revision history with diff view (compare any two revisions). Scheduled publishing: set a future date/time and WordPress publishes automatically. "Pending review" status for multi-author workflows.
+- **Joomla**: Article versioning with ability to restore previous versions. Scheduled start/end publishing dates.
+- **Drupal**: Content moderation module with draft → review → published workflow. Revisions stored per node with diff comparison. Scheduler module for timed publishing.
+
+For DxPress, we want: revision history with restore capability, and scheduled publishing with automatic activation.
+
+@prisma/schema.prisma
+@app/api/posts/route.ts
+@app/api/posts/[id]/route.ts
+@app/admin/posts/[id]/edit/page.tsx
+</context>
+
+<requirements>
+1. **Revision History**:
+
+   a. **Prisma schema**: Add a `PostRevision` model:
+      - id, postId (FK to Post), title, content, excerpt, coverImage
+      - revisionNumber (auto-incrementing per post)
+      - createdAt, createdById (FK to User)
+      - changeNote (optional — "Updated introduction", "Fixed typo")
+
+   b. **API**:
+      - GET /api/posts/[id]/revisions — list all revisions for a post (auth required)
+      - GET /api/posts/[id]/revisions/[revisionId] — get specific revision content
+      - POST /api/posts/[id]/revisions/[revisionId]/restore — restore post to this revision (creates a new revision with the old content)
+
+   c. **Auto-save**: When a post is updated via PUT, automatically create a revision with the previous content before applying the update
+
+   d. **Admin UI**:
+      - "Revision history" panel in post editor sidebar
+      - List of revisions with date, author, and change note
+      - Click to preview a revision
+      - "Restore this version" button
+      - Simple diff view: show what changed between current and selected revision (line-by-line comparison)
+
+2. **Scheduled Publishing**:
+
+   a. **Schema update**: Add `scheduledAt` (nullable DateTime) to Post. Post status becomes: draft, scheduled, published.
+
+   b. **Post editor UI**:
+      - When publishing, show option to "Publish now" or "Schedule for later"
+      - Date/time picker for scheduled date (must be in the future)
+      - Scheduled posts show "Scheduled for [date]" badge in post list
+
+   c. **Publishing mechanism**:
+      - Option A (simple): API endpoint that checks and publishes due posts, called by a cron job or Amplify scheduled function
+      - Option B (serverless): Use a Next.js API route with revalidation — on each public page load, check if any scheduled posts are due and publish them
+      - Implement Option B for simplicity (no additional infrastructure)
+
+   d. **API updates**:
+      - PUT /api/posts/[id] — accept scheduledAt field
+      - GET /api/posts — include status filter (draft/scheduled/published)
+      - Internal: on public blog page load, run a check for due scheduled posts
+
+3. **Revision limits**: Keep last 25 revisions per post. Auto-delete oldest when limit exceeded.
+</requirements>
+
+<implementation>
+- For revision creation, use a Prisma transaction: read current post → create revision with old data → update post with new data
+- Revision numbers should be per-post (not global), use a count query + 1
+- For the diff view, a simple line-by-line comparison is sufficient. Split content by newlines, mark added/removed/unchanged lines. No need for a diff library.
+- Scheduled post check: in the blog page's server component, run a query before fetching posts:
+  ```typescript
+  await prisma.post.updateMany({
+    where: { scheduledAt: { lte: new Date() }, published: false },
+    data: { published: true, publishedAt: new Date() }
+  });
+  ```
+  This is "lazy" scheduling — posts get published when someone visits the blog. For most sites this is fine.
+- The scheduledAt field should be cleared when a post is manually published or unpublished
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/schema.prisma` — add PostRevision model, add scheduledAt to Post
+- `prisma/migrations/*` — new migration
+- `app/api/posts/[id]/route.ts` — create revision on update, handle scheduledAt
+- `app/api/posts/[id]/revisions/route.ts` — GET list revisions
+- `app/api/posts/[id]/revisions/[revisionId]/route.ts` — GET specific, POST restore
+- `app/admin/posts/[id]/edit/page.tsx` — add revision sidebar and schedule UI
+- `components/RevisionHistory.tsx` — revision list and diff viewer
+- `components/SchedulePublish.tsx` — date/time picker for scheduling
+- `app/blog/page.tsx` — add scheduled post check on load
+</output>
+
+<verification>
+- Edit a post → previous version saved as revision automatically
+- Revision list shows all versions with dates and authors
+- Restoring a revision updates the post content and creates a new revision
+- Only last 25 revisions kept per post
+- Schedule a post for 1 minute in the future → after 1 minute, blog page shows it as published
+- Scheduled posts show correct badge in admin post list
+- Cannot schedule for a past date
+</verification>
+
+<success_criteria>
+- Every post edit creates a revision automatically
+- Revisions can be viewed and restored
+- Simple diff shows changes between versions
+- Scheduled publishing works via lazy check
+- Admin UI clearly shows draft/scheduled/published status
+- Revision limit of 25 enforced
+</success_criteria>

--- a/prompts/011-contact-form-analytics.md
+++ b/prompts/011-contact-form-analytics.md
@@ -1,0 +1,127 @@
+<objective>
+Add a contact form and a basic analytics dashboard to DxPress. Contact forms are standard CMS functionality (WordPress has Contact Form 7/WPForms, Joomla has built-in contact, Drupal has Webform). Analytics give site owners insight into their content performance without relying on third-party tools.
+</objective>
+
+<context>
+Read CLAUDE.md for project conventions and tech stack.
+
+Current state:
+- No contact form or way for visitors to reach the site owner
+- No analytics or content metrics (no view counts, no dashboard stats)
+- Admin dashboard (`app/admin/page.tsx`) exists but likely shows minimal information
+
+Comparable CMS features:
+- **WordPress**: Contact Form 7 / WPForms plugins (most sites have one). Jetpack Stats or Google Analytics integration. Dashboard shows at-a-glance: posts, pages, comments, recent activity.
+- **Joomla**: Built-in Contact component with contact forms, categories, and email routing. No built-in analytics but admin dashboard shows popular articles.
+- **Drupal**: Webform module for custom forms. Statistics module tracks content views. Dashboard shows content overview.
+
+For DxPress: a simple contact form with email-less submission (store in database), and a content analytics dashboard tracking page views and popular content.
+
+@app/admin/page.tsx
+@app/api/posts/route.ts
+@prisma/schema.prisma
+</context>
+
+<requirements>
+1. **Contact Form**:
+
+   a. **Prisma schema**: Add `ContactSubmission` model:
+      - id, name, email, subject, message (text), status (NEW, READ, REPLIED, ARCHIVED)
+      - createdAt, readAt
+
+   b. **Public page** (`app/contact/page.tsx`):
+      - Clean form: name, email, subject, message
+      - Client-side validation (all required, valid email format)
+      - Honeypot field for spam prevention
+      - Rate limiting: max 3 submissions per IP per hour
+      - Success state: "Message sent! We'll get back to you soon."
+      - reCAPTCHA is overkill for now — honeypot + rate limit is sufficient
+
+   c. **API**:
+      - POST /api/contact — submit form (public, no auth)
+      - GET /api/admin/contact — list submissions with filters (auth required)
+      - PUT /api/admin/contact/[id] — update status (auth required)
+      - DELETE /api/admin/contact/[id] — delete submission (auth required)
+
+   d. **Admin UI** (`app/admin/contact/page.tsx`):
+      - List submissions sorted by date (newest first)
+      - Filter by status (New, Read, Replied, Archived)
+      - Click to view full message, mark as read automatically
+      - Unread count badge in admin nav
+      - Bulk actions: mark read, archive, delete
+
+2. **Analytics Dashboard**:
+
+   a. **Prisma schema**: Add `PageView` model:
+      - id, path (URL path), referrer (optional), userAgent (optional)
+      - createdAt
+      - No personal data — just aggregate page views
+
+   b. **View tracking**:
+      - Middleware or API route that records page views for public pages
+      - Exclude admin pages, API routes, and bot traffic (basic user-agent check)
+      - Lightweight: fire-and-forget, don't block page rendering
+      - Endpoint: POST /api/analytics/track (called from client-side script)
+
+   c. **Analytics API** (`app/api/admin/analytics/route.ts`):
+      - GET /api/admin/analytics?period=7d|30d|90d|all
+      - Returns: total views, views per day (for chart), top pages, top referrers, top posts by views
+
+   d. **Admin dashboard** (`app/admin/page.tsx`) — enhanced with:
+      - Content overview cards: total posts (published/draft), total pages, total comments (pending), total contact submissions (unread)
+      - Views chart: line chart showing page views over selected period (7d/30d/90d)
+      - Top 5 most viewed posts
+      - Top 5 referrers
+      - Recent activity: last 10 actions (post published, comment received, contact submission)
+      - Use a simple SVG line chart or CSS-based chart (no chart library dependency)
+
+3. **View count display**:
+   - Show view count on post detail pages (small text like "123 views")
+   - Show view count column in admin post list
+</requirements>
+
+<implementation>
+- Contact form: use a server action or API route. Honeypot field is hidden via CSS positioning (off-screen), not display:none.
+- For rate limiting without Redis, use a simple Prisma query: count submissions from the same email in the last hour. Not bulletproof but sufficient.
+- Analytics tracking: use a small client-side script that sends a POST on page load. Use `navigator.sendBeacon` for reliability (fires even on page close).
+- For the dashboard chart, use SVG polyline — calculate x/y points from daily counts, render as an SVG element. No need for Chart.js or Recharts.
+- PageView table will grow — add a cleanup mechanism: delete views older than 90 days (run during analytics API call, or as a scheduled task).
+- Aggregate popular posts by joining PageView with Post on path matching (`/blog/[slug]`).
+</implementation>
+
+<output>
+Create/modify files:
+- `prisma/schema.prisma` — add ContactSubmission, PageView models
+- `prisma/migrations/*` — new migration
+- `app/contact/page.tsx` — public contact form
+- `app/api/contact/route.ts` — POST submit
+- `app/api/admin/contact/route.ts` — GET list
+- `app/api/admin/contact/[id]/route.ts` — PUT status, DELETE
+- `app/admin/contact/page.tsx` — contact submission management
+- `app/api/analytics/track/route.ts` — POST track page view
+- `app/api/admin/analytics/route.ts` — GET analytics data
+- `app/admin/page.tsx` — enhanced dashboard with charts and stats
+- `components/ViewTracker.tsx` — client component that fires beacon on mount
+- `components/SimpleChart.tsx` — SVG line chart component
+- `app/layout.tsx` — add ViewTracker to public pages
+</output>
+
+<verification>
+- Submit contact form → appears in admin with "New" status
+- Honeypot catches bot submissions (hidden field filled = rejected)
+- Admin can view, mark as read, archive, delete submissions
+- Page views tracked on public pages but not admin/API routes
+- Dashboard shows correct counts for posts, pages, comments, submissions
+- Line chart renders daily views for selected period
+- Top posts list shows most viewed content
+- View count displays on individual blog posts
+</verification>
+
+<success_criteria>
+- Contact form works end-to-end with spam prevention
+- Admin can manage submissions with status workflow
+- Page views tracked without impacting page load performance
+- Dashboard provides actionable content insights
+- Charts render without external dependencies
+- View counts accurate and displayed on posts
+</success_criteria>

--- a/prompts/completed/001-project-scaffolding.md
+++ b/prompts/completed/001-project-scaffolding.md
@@ -52,7 +52,7 @@ Thoroughly analyze the needs of a developer portfolio with database-backed conte
    Use many-to-many for Post ↔ Tag. Add appropriate indexes on slug fields.
 
 4. **Database setup**:
-   - Create a `docker-compose.yml` with PostgreSQL 16 service (port 5432, db name `inkwell`, user `inkwell`, password `inkwell_dev`)
+   - Create a `docker-compose.yml` with PostgreSQL 16 service (port 5432, db name `dxpress`, user `dxpress`, password `dxpress_dev`)
    - Create `.env.example` with all required env vars (DATABASE_URL, NEXTAUTH_SECRET, NEXTAUTH_URL, AWS S3 placeholders)
    - Add `.env` to .gitignore (should already be there)
 

--- a/prompts/completed/003-admin-seo-deployment.md
+++ b/prompts/completed/003-admin-seo-deployment.md
@@ -211,7 +211,7 @@ Before declaring complete, verify:
 11. SEO metadata renders correctly (check with View Source)
 12. 404 page renders for invalid routes
 13. All API routes return 401 for unauthenticated requests
-14. Docker build succeeds: `docker build -t inkwell .`
+14. Docker build succeeds: `docker build -t dxpress .`
 </verification>
 
 <success_criteria>


### PR DESCRIPTION
## Summary

- **Rename project** from Inkwell to DxPress across all code, config, docs, and prompts
- **Rename GitHub repo** from `jpDxsoloOrg/inkwell` to `jpDxsoloOrg/dxpress`
- **Add 8 CMS feature plan files** with corresponding GitHub issues comparing gaps to WordPress/Joomla/Drupal:
  - #42 Hierarchical categories/taxonomies
  - #43 Comments system with moderation
  - #44 Dynamic pages and navigation menu management
  - #45 Multi-user roles (Admin, Editor, Author)
  - #46 Browsable media library
  - #47 Full-text search
  - #48 Post revision history and scheduled publishing
  - #49 Contact form and analytics dashboard
- **Add blog post** on deploying Next.js with AWS Amplify, Prisma, and Neon PostgreSQL (including secrets management and credential rotation)

## Test plan
- [ ] Verify all Inkwell/inkwell references are replaced with DxPress/dxpress
- [ ] Verify `npm install` and `npm run build` succeed with renamed package
- [ ] Verify docker-compose uses updated database/container names
- [ ] Verify GitHub issues #42-#49 link to correct plan files
- [ ] Verify blog post published at https://www.jpdxsolo.com/blog/deploying-a-nextjs-app-with-aws-amplify-prisma-and-neon-postgresql

🤖 Generated with [Claude Code](https://claude.com/claude-code)