### PR TITLE
feat: hero cover image on posts and card excerpt truncation

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { Calendar, Clock, ArrowLeft, User } from "lucide-react";
 import { Container } from "@/components/layout";
 import { MdxContent } from "@/components/mdx/MdxContent";
@@ -116,6 +117,20 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             </span>
           </div>
         </header>
+
+        {/* Hero cover image */}
+        {post.coverImage && (
+          <div className="mb-10 overflow-hidden rounded-xl">
+            <Image
+              src={post.coverImage}
+              alt={post.title}
+              width={1200}
+              height={630}
+              className="w-full object-cover"
+              priority
+            />
+          </div>
+        )}
 
         {/* Content with TOC */}
         <div className="lg:grid lg:grid-cols-[1fr_220px] lg:gap-10">

--- a/components/blog/PostCard.tsx
+++ b/components/blog/PostCard.tsx
@@ -44,7 +44,7 @@ export function PostCard({ post }: PostCardProps) {
           </Link>
         </h2>
 
-        <p className="mb-4 flex-1 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
+        <p className="mb-4 flex-1 text-sm leading-relaxed text-neutral-600 line-clamp-3 dark:text-neutral-400">
           {excerpt}
         </p>
 


### PR DESCRIPTION
## Summary
- Display the post cover image as a full-width hero header on individual blog post pages
- Truncate post card excerpts to 3 lines with ellipsis (`line-clamp-3`) to keep cards uniform

## Test plan
- [ ] Open a blog post with a cover image and verify the hero image renders below the header
- [ ] Open a blog post without a cover image and verify no empty space appears
- [ ] View the blog listing and confirm long excerpts are truncated with `...`
- [ ] Check responsive behavior on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)