### PR TITLE
feat: hero cover image on projects and card description truncation

### DIFF
--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { ArrowLeft, Github, ExternalLink } from "lucide-react";
 import { Container } from "@/components/layout";
 import { MdxContent } from "@/components/mdx/MdxContent";
@@ -59,6 +60,18 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
           <p className="mb-8 text-lg text-neutral-600 dark:text-neutral-400">
             {project.description}
           </p>
+          {project.coverImage && (
+            <div className="mb-10 overflow-hidden rounded-xl">
+              <Image
+                src={project.coverImage}
+                alt={project.title}
+                width={1200}
+                height={630}
+                className="w-full object-cover"
+                priority
+              />
+            </div>
+          )}
           <MdxContent source={project.content} />
         </article>
 

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -49,7 +49,7 @@ export function ProjectCard({ project, featured = false }: ProjectCardProps) {
           </Link>
         </h3>
 
-        <p className="mb-4 flex-1 text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
+        <p className="mb-4 flex-1 text-sm leading-relaxed text-neutral-600 line-clamp-3 dark:text-neutral-400">
           {project.description}
         </p>
 


### PR DESCRIPTION
## Summary
- Display the project cover image as a full-width hero header on individual project pages
- Truncate project card descriptions to 3 lines with ellipsis (`line-clamp-3`) to keep cards uniform

## Test plan
- [ ] Open a project with a cover image and verify the hero image renders between description and content
- [ ] Open a project without a cover image and verify no empty space appears
- [ ] View the projects listing and confirm long descriptions are truncated with `...`
- [ ] Check responsive behavior on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)